### PR TITLE
QGA-21 diskStorage MIME type check always returns false

### DIFF
--- a/middlewares/diskStorage.js
+++ b/middlewares/diskStorage.js
@@ -17,7 +17,7 @@ const storage = multer.diskStorage({
 const upload = multer({
   storage,
   fileFilter: (req, file, cb) => {
-    if (file.mimetype != 'image/*') {
+    if (!file.mimetype.match('image/*')) {
       return cb(new AppError('Only image files are allowed!'), false);
     }
     cb(null, true);


### PR DESCRIPTION
  DESCRIPTION: Fixed MIME type check for images. Previously it checked
    whether mimetype is equal to string 'image/*' but as mime types are
    returned as 'type/sub-type' or 'image/png' it should have
    checked if mime type matches that expression.