### PR TITLE
QGA-54 Record patch must check for user level and fields

### DIFF
--- a/controllers/recordsController.js
+++ b/controllers/recordsController.js
@@ -41,26 +41,24 @@ const addRecord = async (req, res, next) => {
 const updateRecord = async (req, res, next) => {
   try {
     const body = { ...req.body };
-    if(accessLevelCheck(req.user.level,'moderator')){
-      const keys = Object.keys(body);
+    if (accessLevelCheck(req.user.level, 'moderator')) {
       let recordUpdate = {};
       let updatedRecord;
 
-      keys.forEach(key => {
-        if (key === 'answers' || key === 'textAnswer') {
-          if (body[key] !== null) {
-            recordUpdate[key] = body[key];
-          }
-        }
-      });
+      if (body.answers) {
+        recordUpdate['answers'] = body.answers;
+      }
+      if (body.textAnswer) {
+        recordUpdate['textAnswer'] = body.textAnswer;
+      }
 
       if (Object.keys(recordUpdate).length <= 0) {
         throw new AppError('Nothing to update');
       } else {
         updatedRecord = await RecordModel.updateById(req.params.recordId, recordUpdate);
       }
-      
-      if(!updatedRecord){
+
+      if (!updatedRecord) {
         throw new AppError("Record not found");
       }
       res.status(200).send({

--- a/controllers/recordsController.js
+++ b/controllers/recordsController.js
@@ -46,10 +46,10 @@ const updateRecord = async (req, res, next) => {
       let updatedRecord;
 
       if (body.answers) {
-        recordUpdate['answers'] = body.answers;
+        recordUpdate.answers = body.answers;
       }
       if (body.textAnswer) {
-        recordUpdate['textAnswer'] = body.textAnswer;
+        recordUpdate.textAnswer = body.textAnswer;
       }
 
       if (Object.keys(recordUpdate).length <= 0) {


### PR DESCRIPTION
  DESCRIPTION: Added user level check before updating record as well as
    check for fields which can be updated (answers and textAnswer).
    Other fields will be ignored if specified.

Also tested with Postman. User with level 'user' cannot change record (only moderator and admin was able to do it) and only answers and/or textAnswer updates (even if trying to update questionId etc.)